### PR TITLE
Cleaned Up Code and Fixed Status Change Problem

### DIFF
--- a/EnnouncementGen.js
+++ b/EnnouncementGen.js
@@ -16,7 +16,7 @@
 
 */
 var showdownConverter;
-
+var sendMessage;
 function getVersion() {
   return "4.1"
 }
@@ -98,8 +98,12 @@ function buildRowHtml(row) {
 function buildEnnouncement(spreadsheet, testOnly) {
   if (arguments.length == 1) {
     var testOnly = false;
+    sendMessage = true;
   } else {
     var testOnly = testOnly;
+    if (testOnly) {
+      sendMessage = false;
+    }
   }
   //Make a variable for today and set the time to 00:00h for ease of checking.
   var TODAY = new Date();
@@ -170,20 +174,21 @@ function buildEnnouncement(spreadsheet, testOnly) {
 
     //TODO: Write sent value AFTER confirming send?
     if (!testOnly) {
-      //Logger.log("Not in testing mode. Writing sent value.");
-      var statusCell = announcementSheet.getRange(2 + i, 9, 1);
-      if ((isApproved && isRecurring && (TODAY.getTime() >= tempEndDate.getTime())) || (!isRecurring && isApproved)) {
-        //End of recurring announcement, or sending a one-time event.
-        statusCell.setValue("Y");
-      }
-      else if (isApproved && isRecurring) {
-        //Unfinished recurring announcement
-        statusCell.setValue("R");
-      }
-      else {
-        //Do not send.
-        statusCell.setValue("N");
-      }
+      
+      // //Logger.log("Not in testing mode. Writing sent value.");
+      // var statusCell = announcementSheet.getRange(2 + i, 9, 1);
+      // if ((isApproved && isRecurring && (TODAY.getTime() >= tempEndDate.getTime())) || (!isRecurring && isApproved)) {
+      //   //End of recurring announcement, or sending a one-time event.
+      //   statusCell.setValue("Y");
+      // }
+      // else if (isApproved && isRecurring) {
+      //   //Unfinished recurring announcement
+      //   statusCell.setValue("R");
+      // }
+      // else {
+      //   //Do not send.
+      //   statusCell.setValue("N");
+      // }
 
     }
     /*
@@ -227,13 +232,15 @@ function sendToSelf() {
 }
 
 function sendEnnouncement() {
+  if (!sendMessage) {
+    return;
+  }
   //Sends the ennouncement.
   var ss = SpreadsheetApp.getActiveSpreadsheet();
   var RECIPIENTS = getRecipients();
   var SUBJECT = getSubject();
 
   var htmlBody = buildEnnouncement(ss);
-
   return sendEnnouncementEmail(RECIPIENTS, SUBJECT, htmlBody, true);
 }
 
@@ -262,10 +269,24 @@ function sendEnnouncementEmail(recipients, subject, htmlBody, doPrompt) {
     var response = ui.alert("Send Ennouncement", "Do you want to send the ennouncement to " + recipients + "?", ui.ButtonSet.YES_NO);
     if (response == ui.Button.YES) {
       var send = true;
+      //Logger.log("Not in testing mode. Writing sent value.");
+      var statusCell = announcementSheet.getRange(2 + i, 9, 1);
+      if ((isApproved && isRecurring && (TODAY.getTime() >= tempEndDate.getTime())) || (!isRecurring && isApproved)) {
+        //End of recurring announcement, or sending a one-time event.
+        statusCell.setValue("Y");
+      }
+      else if (isApproved && isRecurring) {
+        //Unfinished recurring announcement
+        statusCell.setValue("R");
+      }
+      else {
+        //Do not send.
+        statusCell.setValue("N");
+      }
     } else {
       throw ("User chose to not send ennouncement. Stopping.");
     }
-  }``
+  }
   return MailApp.sendEmail({
     to: recipients,
     bcc: getCC(),
@@ -281,7 +302,7 @@ function sendRequest() {
   if (response == ui.Button.YES) {
     var send = true;
   } else {
-    throw ("User chose to not send ennouncement request. Stopping.");
+    throw ("User chose to not send ennouncement. Stopping.");
   }
   var htmlBody = buildRequestHtml();
 

--- a/EnnouncementGen.js
+++ b/EnnouncementGen.js
@@ -265,7 +265,7 @@ function sendEnnouncementEmail(recipients, subject, htmlBody, doPrompt) {
     } else {
       throw ("User chose to not send ennouncement. Stopping.");
     }
-  }
+  }``
   return MailApp.sendEmail({
     to: recipients,
     bcc: getCC(),
@@ -281,7 +281,7 @@ function sendRequest() {
   if (response == ui.Button.YES) {
     var send = true;
   } else {
-    throw ("User chose to not send ennouncement. Stopping.");
+    throw ("User chose to not send ennouncement request. Stopping.");
   }
   var htmlBody = buildRequestHtml();
 


### PR DESCRIPTION
This request includes two different commits that address two different issues..

Commit [a0fef9b](https://github.com/afwolfe/EnnouncementGenerator/commit/a0fef9bd3b43815849cbd61bb703f624e7653fbc) addresses a misleading console output when cancelling send ennouncement request that falsely reports that it did not send an ennouncement email (as opposed to a request)

Commit [3cc96ba] (https://github.com/afwolfe/EnnouncementGenerator/commit/3cc96ba21d1f04b96219aa6e414a775a206b0b47) addresses the issue of statuses being incorrectly updated when cancelling sending an email by changing the update's position in the program flow.